### PR TITLE
Fix problem referencing bootstrap

### DIFF
--- a/static_src/stylesheets/shiori.scss
+++ b/static_src/stylesheets/shiori.scss
@@ -46,7 +46,7 @@ $red: #e74c3c;
 
 @import "theme-color";
 @import "custom-bootstrap-variables";
-@import "bootstrap-sass/assets/stylesheets/bootstrap";
+@import "../../node_modules/bootstrap-sass/assets/stylesheets/bootstrap";
 
 $space-xs: $line-height-computed * 1;
 $space-sm: $line-height-computed * 1.5;


### PR DESCRIPTION
the @import of bootstrap stylesheets references a relative path that doesn't exist on a clean install. This change references the bootstrap installed by npm a couple of directories up.